### PR TITLE
Add Logic to run `terraform refresh`

### DIFF
--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -230,6 +230,11 @@ module Terraforming
       execute(Terraforming::Resource::SNSTopicSubscription, options)
     end
 
+    desc "refresh", "terraform refresh"
+    def refresh
+      system("terraform refresh")
+    end
+
     private
 
     def configure_aws(options)


### PR DESCRIPTION
1. Why is this change necessary?
We need a way to update the state from v1 to v4. But terraform already
does this, so a natural way is to use terraform to perform this

2. How does it address the issue?
This call `terraform refresh` with the use of `terraforming refresh`

3. What side effects does this change have?
None